### PR TITLE
Duplicate key on serialization

### DIFF
--- a/MadMilkman.Ini/IniUtilities/IniSerializer.cs
+++ b/MadMilkman.Ini/IniUtilities/IniSerializer.cs
@@ -14,7 +14,9 @@ namespace MadMilkman.Ini
         {
             foreach (var propertyPair in GetPropertyPairs(typeof(T)))
             {
-                var key = section.Keys.Add(propertyPair.Key);
+                var key = section.ParentFile.options.KeyDuplicate == IniDuplication.Disallowed
+                    ? section.Keys[propertyPair.Key] ?? section.Keys.Add(propertyPair.Key) 
+                    : section.Keys.Add(propertyPair.Key);
                 if (key.ParentCollectionCore != null)
                     SetKeyValue(propertyPair.Value, source, key);
             }


### PR DESCRIPTION
If KeyDuplicate = Disallowed, then during serialization, it first checks whether there is such a key, and only if not, creates a new one.
